### PR TITLE
connect to Plug.Accepts to access Accept-Language

### DIFF
--- a/lib/sign_dict_web/endpoint.ex
+++ b/lib/sign_dict_web/endpoint.ex
@@ -51,6 +51,7 @@ defmodule SignDictWeb.Endpoint do
     read_timeout: 60_000
   )
 
+  plug(Plug.Accepts)
   plug(Plug.MethodOverride)
   plug(Plug.Head)
 


### PR DESCRIPTION
Browser language is sent in request headers under Accept-Language. This change connects to the Plug.Accepts plug to allow the app to parse the Accepts headers, including the Accept-Language header. This will then give access to this information where the app decides which language to serve, to make a more accurate decision.